### PR TITLE
Fix responsive header style

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,8 +1,8 @@
 <header
   class="fixed top-5 left-1/2 transform -translate-x-1/2
-         w-[90%] h-[85px]
+         w-[90%] sm:h-16 h-[85px]
          flex items-center justify-between
-         px-6
+         sm:px-4 px-6
          rounded-[30px]
          z-50"
   style="background: linear-gradient(115deg, #ffffff 30%, #1a2b4c 30%);"


### PR DESCRIPTION
## Summary
- make the header height and padding responsive so it shrinks on small screens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b0c691688326ab3ef707269b8acb